### PR TITLE
Updates to lambda transofrmation to make it Windows compatible

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,6 +23,10 @@ def save_checkpoint(model, optimizer, step, checkpoint_dir):
     print("Saved checkpoint: {}".format(checkpoint_path))
 
 
+def shift(x):
+    return x - 0.5
+
+
 def train_gssoft(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -48,17 +52,15 @@ def train_gssoft(args):
     else:
         global_step = 0
 
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Lambda(shift)
+    ])
     training_dataset = datasets.CIFAR10("./CIFAR10", train=True, download=True,
-                                        transform=transforms.Compose([
-                                            transforms.ToTensor(),
-                                            lambda x: x - 0.5
-                                        ]))
+                                        transform=transform)
 
     test_dataset = datasets.CIFAR10("./CIFAR10", train=False, download=True,
-                                    transform=transforms.Compose([
-                                        transforms.ToTensor(),
-                                        lambda x: x - 0.5
-                                    ]))
+                                    transform=transform)
 
     training_dataloader = DataLoader(training_dataset, batch_size=args.batch_size, shuffle=True,
                                      num_workers=args.num_workers, pin_memory=True)
@@ -165,17 +167,15 @@ def train_vqvae(args):
     else:
         global_step = 0
 
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Lambda(shift)
+    ])
     training_dataset = datasets.CIFAR10("./CIFAR10", train=True, download=True,
-                                        transform=transforms.Compose([
-                                            transforms.ToTensor(),
-                                            lambda x: x - 0.5
-                                        ]))
+                                        transform=transform)
 
     test_dataset = datasets.CIFAR10("./CIFAR10", train=False, download=True,
-                                    transform=transforms.Compose([
-                                        transforms.ToTensor(),
-                                        lambda x: x - 0.5
-                                    ]))
+                                    transform=transform)
 
     training_dataloader = DataLoader(training_dataset, batch_size=args.batch_size, shuffle=True,
                                      num_workers=args.num_workers, pin_memory=True)


### PR DESCRIPTION
Move from using a lambda in transforms.Compose to using transforms.Lambda, so that the transforms `list` can be pickled on Windows and used with multiple `DataLoader` workers.

This alleviates errors of this nature:

`C:/w/1/s/tmp_conda_3.7_055457/conda/conda-bld/pytorch_1565416617654/work/aten/src/THC/THCTensorScatterGather.cu:100: block: [8,0,0], thread: [447,0,0] Assertion `indexValue >= 0 && indexValue < src.sizes[dim]` failed.`

See problem discussion [here](https://github.com/belskikh/kekas/issues/26) and see [here](https://discuss.pytorch.org/t/cant-pickle-local-object-dataloader-init-locals-lambda/31857/10) for discussion of the implemented solution.